### PR TITLE
Provide settings checkbox

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,13 +8,10 @@ class NevermindSkill(MycroftSkill):
     def __init__(self):
         super(NevermindSkill, self).__init__(name='NevermindSkill')
 
-        # This setting would be obeyed if there were a way to toggle it.
-        self.feedback = (self.settings.get('verbal_feedback') is not False)
-
     @intent_handler(IntentBuilder('dismiss.mycroft').require('Nevermind'))
     def handle_dismiss_intent(self, message):
         self.log.info("User dismissed Mycroft.")
-        if self.feedback:
+        if self.settings.get('verbal_feedback', False):
             self.speak_dialog('dismissed')
 
 

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -1,0 +1,18 @@
+{
+    "name": "Nevermind",
+    "skillMetadata": {
+        "sections": [
+            {
+                "name": "Verbal Feedback",
+                "fields": [
+                    {
+                        "name": "verbal_feedback",
+                        "type": "checkbox",
+                        "label": "Provide verbal feedback when dismissed",
+                        "value": "false"
+                    }
+                ]
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Hey Chance, was just checking out your Skill and saw that there wasn't yet a settings block. Thought a PR would be the easiest way to describe it.

The `settingsmeta.json` file creates the content at home.mycroft.ai/skills

Then I've shifted the setting check in the Skill. The `init` method is only called once when the Skill is loaded, so the setting would only ever be checked once, and if a user changed the setting on Home, the new setting would get pulled down to `settings.json` but the Skill wouldn't go back to check it. You can set a callback to run when the settings change, but since this setting is only used the once, it seems easier to just check it directly in the intent handler.

Anyway, let me know if you have any questions. Feel free to use this or not :)

If you do any updates or merge this, please pull the changes down to your machine and rerun MSK submit to update the PR to the mycroft-skills repo.