### PR TITLE
fixes broken settings check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -10,10 +10,9 @@ class NevermindSkill(MycroftSkill):
 
     @intent_handler(IntentBuilder('dismiss.mycroft').require('Nevermind'))
     def handle_dismiss_intent(self, message):
-        self.log.info("User dismissed Mycroft.")
-        if self.settings.get('verbal_feedback', False):
+        if self.settings.get('verbal_feedback') == False:
             self.speak_dialog('dismissed')
-
+        self.log.info("User dismissed Mycroft.")
 
 def create_skill():
     return NevermindSkill()

--- a/settingsmeta.json
+++ b/settingsmeta.json
@@ -9,7 +9,7 @@
                         "name": "verbal_feedback",
                         "type": "checkbox",
                         "label": "Provide verbal feedback when dismissed",
-                        "value": "false"
+                        "value": "False"
                     }
                 ]
             }


### PR DESCRIPTION
settings.get(setting, value) wasn't working. I'm sure the reason will become obvious when I'm more familiar with the API, but I wasn't able to debug it offhand. I tried a few values, and they just weren't working, so I've replaced that check with an old-fashioned equality check:

`if settings.get("verbal_feedback") == False`

and it's working. I changed the case in settings.meta by accident, but it's JSON, so no biggie.